### PR TITLE
Throw an exception if a Java method returns NaN/+inf/-inf.

### DIFF
--- a/java_src/javaErlang/JavaErlang.java
+++ b/java_src/javaErlang/JavaErlang.java
@@ -903,10 +903,16 @@ public class JavaErlang {
     }
 
     public static OtpErlangObject map_to_erlang_double(final double value) {
+        if (Double.isNaN(value) || Double.isInfinite(value))
+          throw new ArithmeticException("Can't represent infinite or NaN doubles");
+
         return new OtpErlangDouble(value);
     }
 
     public static OtpErlangObject map_to_erlang_float(final float value) {
+        if (Float.isNaN(value) || Float.isInfinite(value))
+            throw new ArithmeticException("Can't represent infinite or NaN floats");
+
         return new OtpErlangDouble(value);
     }
 


### PR DESCRIPTION
Erlang doesn't allow floating-point numbers to be NaN or +inf or -inf (it raises an exception if you e.g. do 0.0/0.0). So the following code should probably raise an exception too:

```erlang
nan() ->
  {ok, Node} = java:start_node(),
  java:get_static(Node, 'java.lang.Double', 'NaN').
```

Unfortunately what it actually does is this:

```
=WARNING REPORT==== 16-Oct-2015::17:15:17 ===
'blah@localhost' got a corrupted external term from 'javaNode_100@localhost' on distribution channel 7674
<<...,131,104,2,100,0,5,118,97,108,117,101,70,127,248,0,0,0,0,0,0>>
ATOM_CACHE_REF translations: none
```

at which point the Java node becomes unresponsive. The external term represents {value, NaN} and Erlang refuses to turn it into a term.

This patch checks that you haven't tried to return NaN/+inf/-inf and converts them into an `ArithmeticException` instead, so you now get:

```
WARNING: 
java.lang.ArithmeticException: Can't represent infinite or NaN doubles
        at javaErlang.JavaErlang.map_to_erlang_double(JavaErlang.java:907)
        at javaErlang.JavaErlang.map_to_erlang(JavaErlang.java:877)
        at javaErlang.ThreadMsgHandler.array_to_list(ThreadMsgHandler.java:174)
        at javaErlang.ThreadMsgHandler.handleCall(ThreadMsgHandler.java:147)
        at javaErlang.ThreadMsgHandler.do_receive(ThreadMsgHandler.java:100)
        at javaErlang.ThreadMsgHandler.run(ThreadMsgHandler.java:74)
        at java.lang.Thread.run(Thread.java:745)
** exception throw: {java_exception,{object,2,0,2,101}}
```