### PR TITLE
fix recursive default_options call

### DIFF
--- a/src/java.erl
+++ b/src/java.erl
@@ -953,7 +953,7 @@ default_option(java_executable) ->
 default_option(call_timeout) ->
     10000;
 default_option(log_level) ->
-    debug.
+    notice.
 
 %% @doc
 %% Returns the major version number of the JavaErlang library.


### PR DESCRIPTION
if debug mode is enabled node tried to call default_options which called
log macro, which in turn tried to call default_options
