### PR TITLE
Append needed flags for compiling the c_src

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -18,17 +18,17 @@ C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -arch x86_64 -finline-functions -Wall
-	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
+	CFLAGS += -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS += -O3 -arch x86_64 -finline-functions -Wall
+	LDFLAGS += -arch x86_64 -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -finline-functions -Wall
+	CFLAGS += -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS += -O3 -finline-functions -Wall
 else ifeq ($(UNAME_SYS), Linux)
 	CC ?= gcc
-	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -finline-functions -Wall
+	CFLAGS += -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS += -O3 -finline-functions -Wall
 endif
 
 CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)


### PR DESCRIPTION
On my local environment, I have specific CFLAGS and LDFLAGS defined in my environment. However, I also need the options you've specified here in the Makefile. Rather than using ?= to conditionally assign them, I'm just using += to append them.