### PR TITLE
Fix for OTP 26. And use halt instead of stop

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -6,9 +6,9 @@ BASEDIR := $(abspath $(CURDIR)/..)
 PROJECT ?= $(notdir $(BASEDIR))
 PROJECT := $(strip $(PROJECT))
 
-ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")
-ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)]).")
-ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)]).")
+ERTS_INCLUDE_DIR ?= $(shell erl -noshell -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)])." -s erlang halt)
+ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)])." -s erlang halt)
+ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)])." -s erlang halt)
 
 C_SRC_DIR = $(CURDIR)
 C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so

--- a/java_src/Makefile
+++ b/java_src/Makefile
@@ -2,7 +2,7 @@
 
 CURDIR := .
 
-JINTERFACE_PRIV_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:priv_dir(jinterface)]).")
+JINTERFACE_PRIV_DIR ?= $(shell erl -noshell -eval "io:format(\"~s\", [code:priv_dir(jinterface)])." -s erlang halt)
 
 JAVA_SRC_DIR = $(CURDIR)/java_src
 JAVA_SRC_OUTPUT ?= $(CURDIR)/priv/JavaErlang.jar


### PR DESCRIPTION
Seems the use of `-s init stop` before the eval expr wont work in otp26.